### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -46,7 +46,7 @@ jobs:
       run: mypy tofea
 
     - name: Test with pytest
-      run: pytest --doctest-modules --cov tofea
+      run: pytest --cov tofea
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         name: pytest
         entry: pytest --doctest-modules --cov tofea
         language: system
+        pass_filenames: false
       - id: build
         name: build
         entry: mkdocs build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,12 +34,34 @@ dev = ["tofea[all,docs]", "ruff", "mypy", "pre-commit"]
 Source = "https://github.com/mrbaozi/tofea"
 
 [tool.ruff]
-select = ["E", "W", "F", "B", "I", "UP", "C4", "NPY", "PT", "SIM", "ARG", "PERF", "PTH"]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+  "E",
+  "W",
+  "F",
+  "B",
+  "I",
+  "UP",
+  "C4",
+  "NPY",
+  "PT",
+  "SIM",
+  "ARG",
+  "PERF",
+  "PTH",
+  "TID",
+  "PLE",
+  "PLC",
+  "RSE",
+  "PIE",
+  "RUF",
+]
 fixable = ["ALL"]
 ignore = ["F821"]
 unfixable = ["F401", "F841"]
-line-length = 88
-target-version = "py310"
 
 [tool.mypy]
 python_version = "3.10"
@@ -48,3 +70,5 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]
 addopts = "--doctest-modules"
+testpaths = ["tofea", "tests"]
+env = ["MPLBACKEND=Agg"]

--- a/tests/test_fea2d.py
+++ b/tests/test_fea2d.py
@@ -59,12 +59,8 @@ class TestFEA2DK:
     def test_compliance_grads(self, fea2d_k_instance, x_and_b, rng):
         x, _ = x_and_b
         d = rng.random(fea2d_k_instance.dofs.shape)
-        check_grads(
-            lambda x_: fea2d_k_instance.compliance(x_, d), modes=["fwd", "rev"], order=1
-        )(x)
-        check_grads(
-            lambda d_: fea2d_k_instance.compliance(x, d_), modes=["fwd", "rev"], order=1
-        )(d)
+        check_grads(lambda x_: fea2d_k_instance.compliance(x_, d), modes=["fwd", "rev"], order=1)(x)
+        check_grads(lambda d_: fea2d_k_instance.compliance(x, d_), modes=["fwd", "rev"], order=1)(d)
 
 
 class TestFEA2DT:

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -24,9 +24,7 @@ def test_solve_coo_entries_grad(rng, n, solver, mode):
 
     _solver = get_solver(solver)
 
-    check_grads(
-        lambda x: solve_coo(x, (m.row, m.col), b, _solver), modes=[mode], order=1
-    )(m.data)
+    check_grads(lambda x: solve_coo(x, (m.row, m.col), b, _solver), modes=[mode], order=1)(m.data)
 
 
 @pytest.mark.parametrize("n", [10, 11])
@@ -40,6 +38,4 @@ def test_solve_coo_b_grad(rng, n, solver, mode):
 
     _solver = get_solver(solver)
 
-    check_grads(
-        lambda x: solve_coo(m.data, (m.row, m.col), x, _solver), modes=[mode], order=1
-    )(b)
+    check_grads(lambda x: solve_coo(m.data, (m.row, m.col), x, _solver), modes=[mode], order=1)(b)

--- a/tofea/__init__.py
+++ b/tofea/__init__.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 __all__ = [
+    "DEFAULT_SOLVER",
+    "__version__",
     "elements",
     "fea2d",
     "primitives",
     "solvers",
-    "DEFAULT_SOLVER",
-    "__version__",
 ]
 
 __version__ = "0.1.0"

--- a/tofea/elements.py
+++ b/tofea/elements.py
@@ -113,9 +113,7 @@ class Q4Element_K(Q4Element):
             ]
         )
 
-        C = (E / (1 - nu**2)) * sympy.Matrix(
-            [[1, nu, 0], [nu, 1, 0], [0, 0, (1 - nu) / 2]]
-        )
+        C = (E / (1 - nu**2)) * sympy.Matrix([[1, nu, 0], [nu, 1, 0], [0, 0, (1 - nu) / 2]])
 
         dK = B.T * C * B
         K = dK.integrate((x, -a, a), (y, -b, b))

--- a/tofea/fea2d.py
+++ b/tofea/fea2d.py
@@ -169,9 +169,7 @@ class FEA2D_K(FEA2D):
     def compliance(self, x: NDArray, displacement: NDArray) -> NDArray:
         """Compliance objective for ``x`` and ``displacement``."""
         dofmap = np.reshape(self.e2sdofmap.T, (-1, *self.shape))
-        c = anp.einsum(
-            "ixy,ij,jxy->xy", displacement[dofmap], self.element, displacement[dofmap]
-        )
+        c = anp.einsum("ixy,ij,jxy->xy", displacement[dofmap], self.element, displacement[dofmap])
         return anp.sum(x * c)
 
 

--- a/tofea/solvers.py
+++ b/tofea/solvers.py
@@ -26,9 +26,7 @@ class Solver(ABC):
 class SuperLU(Solver):
     """`scipy.sparse.linalg.splu` wrapper."""
 
-    def __init__(
-        self, **options: float | int | bool | str | Mapping[str, bool]
-    ) -> None:
+    def __init__(self, **options: float | int | bool | str | Mapping[str, bool]) -> None:
         """Create a new ``SuperLU`` solver instance."""
         # store solver-specific context on the instance to avoid cross-talk
         self._ctx: dict[str, Any] = {"splu": partial(splu, **options)}


### PR DESCRIPTION
## Summary
- update ruff config
- extend lint rules
- add pytest env and testpaths settings
- fix failing pre-commit hook

## Testing
- `ruff check .`
- `ruff format --check .`
- `mypy tofea`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856f399aa548332bef956046e7e146d

<!-- greptile_comment -->

## Greptile Summary

Comprehensive CI/testing infrastructure updates focused on improving code quality checks and test execution efficiency. Key changes include extended linting rules and optimized test configurations.

- Added new Ruff lint rules (TID, PLE, PLC, RSE, PIE, RUF) and increased line length to 100 in `pyproject.toml`
- Removed `--doctest-modules` from pytest CI workflow in `.github/workflows/run_tests.yml` for faster execution
- Added matplotlib Agg backend configuration in `pyproject.toml` for CI compatibility
- Modified `.pre-commit-config.yaml` to improve pytest hook behavior with `pass_filenames: false`
- Applied consistent code formatting across multiple files (`tofea/elements.py`, `tofea/fea2d.py`, `tofea/solvers.py`)



<!-- /greptile_comment -->