### PR TITLE
Optimize element assembly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "numpy>=1.26",
     "scipy>=1.11",
-    "sympy>=1.13",
     "autograd>=1.8",
 ]
 
@@ -71,4 +70,3 @@ ignore_missing_imports = true
 filterwarnings = ["ignore::DeprecationWarning"]
 addopts = "--doctest-modules"
 testpaths = ["tofea", "tests"]
-env = ["MPLBACKEND=Agg"]

--- a/tests/test_elements.py
+++ b/tests/test_elements.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from tofea.elements import Q4Element_K, Q4Element_T
+from tofea.elements import Q4Element, Q4Element_K, Q4Element_T
 
 
 class TestQ4ElementK:
@@ -24,3 +24,12 @@ class TestQ4ElementT:
         element = q4element_t_instance.element
         assert isinstance(element, np.ndarray)
         assert element.shape == (4, 4)
+
+
+def test_q4element_utilities():
+    elem = Q4Element()
+    points = elem.gauss_points()
+    assert len(points) == 4
+    dxi, deta = elem.grad_shape_funcs(0.0, 0.0)
+    np.testing.assert_allclose(dxi, [-0.25, 0.25, 0.25, -0.25])
+    np.testing.assert_allclose(deta, [-0.25, -0.25, 0.25, 0.25])

--- a/tests/test_fea2d.py
+++ b/tests/test_fea2d.py
@@ -1,6 +1,9 @@
 import numpy as np
 import pytest
 from autograd.test_util import check_grads
+from numpy.testing import assert_allclose
+from scipy.sparse import coo_matrix
+from scipy.sparse.linalg import spsolve
 
 from tofea.fea2d import FEA2D_K, FEA2D_T
 
@@ -107,3 +110,43 @@ class TestFEA2DT:
             modes=["fwd", "rev"],
             order=1,
         )(b)
+
+
+def test_fea2d_k_solution_matches_spsolve():
+    fixed = np.zeros((2, 2, 2), dtype=bool)
+    fixed[0] = True
+    fem = FEA2D_K(fixed)
+    x = np.array([[1.0]])
+    load = np.zeros_like(fixed, dtype=float)
+    load[1, 1, 1] = 1.0
+
+    disp = fem.displacement(x, load)
+
+    data, indices = fem.global_mat(x)
+    k = coo_matrix(
+        (data, (indices[0], indices[1])), shape=(len(fem.freedofs), len(fem.freedofs))
+    ).tocsc()
+    u_free = spsolve(k, load.ravel()[fem.freedofs])
+    expected = np.concatenate([u_free, np.zeros(len(fem.fixdofs))])[fem.index_map]
+
+    assert_allclose(disp, expected)
+
+
+def test_fea2d_t_solution_matches_spsolve():
+    fixed = np.zeros((2, 2), dtype=bool)
+    fixed[0, 0] = True
+    fem = FEA2D_T(fixed)
+    x = np.array([[1.0]])
+    load = np.zeros_like(fixed, dtype=float)
+    load[1, 1] = 1.0
+
+    temp = fem.temperature(x, load)
+
+    data, indices = fem.global_mat(x)
+    k = coo_matrix(
+        (data, (indices[0], indices[1])), shape=(len(fem.freedofs), len(fem.freedofs))
+    ).tocsc()
+    t_free = spsolve(k, load.ravel()[fem.freedofs])
+    expected = np.concatenate([t_free, np.zeros(len(fem.fixdofs))])[fem.index_map]
+
+    assert_allclose(temp, expected)


### PR DESCRIPTION
## Summary
- replace expensive SymPy integrations with numerical 2x2 Gauss quadrature
- keep type checking happy with explicit NDArray annotations
- remove SymPy entirely and add correctness tests for solvers
- provide reusable utilities in `Q4Element` and use them in element classes
- drop unused `env` setting from pytest configuration

## Testing
- `ruff check . --fix`
- `ruff format .`
- `mypy tofea`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856f95de66483329f32a61d5e3ac0aa

<!-- greptile_comment -->

## Greptile Summary

Major optimization of the finite element analysis implementation by replacing SymPy symbolic integration with numerical 2x2 Gauss quadrature, significantly improving performance while maintaining accuracy.

- Complete removal of SymPy dependency from `pyproject.toml` and codebase, streamlining dependencies
- Added new `Q4Element` base class in `tofea/elements.py` with shared quadrature utilities for element matrix assembly
- Implemented numerical 2x2 Gauss quadrature in `tofea/elements.py`, replacing expensive symbolic computations
- Enhanced type safety with explicit NDArray annotations throughout element implementations
- Added solver correctness tests in `tests/test_fea2d.py` comparing FEA2D implementations against SciPy's spsolve



<!-- /greptile_comment -->